### PR TITLE
Make domains an optional input and make the basic example easier to deploy

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,5 +1,32 @@
 # Basic example
 
-A simple example with 3 servers and a load balancer that distributes the traffic between them. The example assumes that each of the servers has some application listening on port 3000.
+A simple example with 3 servers and a load balancer that distributes the traffic between them. The example uses an user-data script to launch a HTTP server listening to port 80 on each server. The example does not enable TLS on frontend by default.
 
-Once you deploy it, go to your domain settings and add a CNAME record that points to the `lb_url` output variable. After the change gets propagated, all the traffic to your domain (`my.domain.com` in this example) will be distributed among the 3 servers.
+## Getting started
+
+To deploy private network, three servers, and load balancer on your UpCloud account, run:
+
+```bash
+terraform init
+terraform apply
+```
+
+Once the deployment is complete and load balancer has reached `running` state you can use `curl` or your browser to send request to the load balancer available in the URL defined by `lb_url` output variable:
+
+```bash
+curl $(terraform output -raw lb_url)
+```
+
+Note that it might take some time for the DNS name to propagate. During this time the above `curl` command will likely fail with `Could not resolve host: ...` error message.
+
+The output should include hostname of the backend server, for example:
+
+```txt
+Hello from lb-module-basic-example-server-1
+```
+
+## Enable TLS
+
+The example does not enable TLS on frontend by default. To enable TLS, uncomment `domains` variable in [main.tf](./main.tf) and replace example domain with your domain. Change also the value for `frontend_port` from `80` to `443`.
+
+Deploy the changes with `terraform apply`. When the deployment is completed, go to your domain settings and add a CNAME record that points to the `lb_url` output variable. After the change gets propagated, all the traffic to your domain will be distributed among the 3 servers.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,8 +9,12 @@ terraform {
 
 provider "upcloud" {}
 
+locals {
+  prefix = "lb-module-basic-example-"
+}
+
 resource "upcloud_network" "network" {
-  name = "my_network"
+  name = "${local.prefix}net"
   zone = "pl-waw1"
 
   ip_network {
@@ -22,14 +26,24 @@ resource "upcloud_network" "network" {
 
 resource "upcloud_server" "webservers" {
   count    = 3
-  hostname = "webserver${count.index}"
-  title    = "webserver_${count.index}"
+  hostname = "${local.prefix}server-${count.index}"
+  title    = "${local.prefix}server-${count.index}"
   zone     = "pl-waw1"
-  plan     = "1xCPU-2GB"
+  plan     = "1xCPU-1GB"
+
+  # Use user-data script to install and launch http server on start
+  metadata  = true
+  user_data = file("${path.module}/user-data-script.sh")
 
   template {
     storage = "Ubuntu Server 20.04 LTS (Focal Fossa)"
     size    = 25
+    title   = "${local.prefix}storage-${count.index}"
+  }
+
+  # Required to have internet access when installing httpd on launch
+  network_interface {
+    type = "public"
   }
 
   network_interface {
@@ -45,12 +59,18 @@ resource "upcloud_server" "webservers" {
 module "load_balancer" {
   source = "UpCloudLtd/basic-loadbalancer/upcloud"
 
-  name                = "my_loadbalancer"
+  name                = "${local.prefix}lb"
   zone                = "pl-waw1"
   network             = upcloud_network.network.id
-  backend_servers     = [for v in upcloud_server.webservers : v.network_interface.1.ip_address]
-  backend_server_port = 3000
-  domains             = ["my.domain.net"]
+  backend_servers     = [for v in upcloud_server.webservers : v.network_interface.2.ip_address]
+  backend_server_port = 80
+
+  # To enable TLS on the frontend:
+  # - Uncomment and replace example.com with your domain
+  # - Change frontend port from 80 to 443
+
+  # domains       = ["example.com"]
+  frontend_port = 80
 }
 
 output "lb_url" {

--- a/examples/basic/user-data-script.sh
+++ b/examples/basic/user-data-script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Install HTTP server and firewall
+apt update
+apt install -y apache2 ufw
+
+# Add hostname to HTTP response to identify back-end server
+echo "Hello from $(hostname)" > /var/www/html/index.html
+
+# Allow incoming traffic only from private network
+ufw enable
+ufw allow in on eth2

--- a/main.tf
+++ b/main.tf
@@ -40,13 +40,15 @@ resource "upcloud_loadbalancer_frontend" "main" {
 }
 
 resource "upcloud_loadbalancer_dynamic_certificate_bundle" "main" {
+  count     = length(var.domains) > 0 ? 1 : 0
   name      = "main"
   hostnames = var.domains
   key_type  = "rsa"
 }
 
 resource "upcloud_loadbalancer_frontend_tls_config" "main" {
+  count              = length(var.domains) > 0 ? 1 : 0
   frontend           = upcloud_loadbalancer_frontend.main.id
   name               = "main"
-  certificate_bundle = upcloud_loadbalancer_dynamic_certificate_bundle.main.id
+  certificate_bundle = upcloud_loadbalancer_dynamic_certificate_bundle.main[count.index].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,7 @@ variable "max_server_sessions" {
 }
 
 variable "domains" {
-  description = "List of domains that will be used with this load balancer. All of the domains in this list should have a CNAME record set pointing to load balancer DNS name (see `dns_name` output)"
+  description = "List of domains that will be used with this load balancer. All of the domains in this list should have a CNAME record set pointing to load balancer DNS name (see `dns_name` output). If left empty, no TLS configuration will be created for the load balancer frontend."
   type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
Not sure if want to encourage not using TLS config and HTTPS, but this would make learning load balancer deployment a bit easier as there is no need to work with DNS records when trying the deployment for the first time.